### PR TITLE
Rewrote "stability" as "Stability".

### DIFF
--- a/Project/PropertiesForm.wxcp
+++ b/Project/PropertiesForm.wxcp
@@ -3905,7 +3905,7 @@
           }, {
            "type": "string",
            "m_label": "Label:",
-           "m_value": "stability"
+           "m_value": "Stability"
           }, {
            "type": "bitmapPicker",
            "m_label": "Bitmap File:",

--- a/Project/PropertiesFormBase.cpp
+++ b/Project/PropertiesFormBase.cpp
@@ -361,7 +361,7 @@ SimulationsSettingsFormBase::SimulationsSettingsFormBase(wxWindow* parent, wxWin
     m_textCtrlPFGaussTolerance->SetMinSize(wxSize(20,-1));
     
     m_panelStability = new wxPanel(m_notebook, wxID_ANY, wxDefaultPosition, wxDLG_UNIT(m_notebook, wxSize(-1,-1)), wxTAB_TRAVERSAL);
-    m_notebook->AddPage(m_panelStability, _("stability"), false);
+    m_notebook->AddPage(m_panelStability, _("Stability"), false);
     
     wxBoxSizer* boxSizerLvl2_3 = new wxBoxSizer(wxVERTICAL);
     m_panelStability->SetSizer(boxSizerLvl2_3);


### PR DESCRIPTION
Ciao, bello!

I fixed the capitalization in the "Stability" tab under the "Simulation settings" form: it was written in all small caps.
![small_caps_stability_tab](https://user-images.githubusercontent.com/3703639/140617558-67b3005d-f4ec-409f-8f8b-21ba4a248450.png)
![fixed_capitalization_of_stability_tab](https://user-images.githubusercontent.com/3703639/140617560-7d1ccf77-6812-4426-aeeb-9075710385ab.png)

