### PR TITLE
Included wx/brush header to complete compilation.

### DIFF
--- a/Project/Exponential.cpp
+++ b/Project/Exponential.cpp
@@ -18,6 +18,7 @@
 #include "Exponential.h"
 #include "ExponentialForm.h"
 #include <wx/pen.h>
+#include <wx/brush.h>
 
 Exponential::Exponential(int id) : ControlElement(id)
 {

--- a/Project/Limiter.cpp
+++ b/Project/Limiter.cpp
@@ -18,6 +18,7 @@
 #include "Limiter.h"
 #include "LimiterForm.h"
 #include <wx/pen.h>
+#include <wx/brush.h>
 
 Limiter::Limiter(int id) : ControlElement(id)
 {

--- a/Project/RateLimiter.cpp
+++ b/Project/RateLimiter.cpp
@@ -18,6 +18,7 @@
 #include "RateLimiter.h"
 #include "RateLimiterForm.h"
 #include <wx/pen.h>
+#include <wx/brush.h>
 
 RateLimiter::RateLimiter(int id) : ControlElement(id)
 {

--- a/Project/Sum.cpp
+++ b/Project/Sum.cpp
@@ -19,6 +19,7 @@
 #include "Sum.h"
 #include "SumForm.h"
 #include <wx/pen.h>
+#include <wx/brush.h>
 
 Sum::Sum(int id) : ControlElement(id)
 {


### PR DESCRIPTION
On Fedora 35, either using g++ or clang++, I can only completely compile and build your software if I include wx/brush header in some of your files; otherwise I get these kind of compile errors:

```
/home/roni/psp/PSP/Project/Exponential.cpp: In member function ‘virtual void Exponential::DrawDC(wxPoint2DDouble, double, wxGraphicsContext*) const’:
/home/roni/psp/PSP/Project/Exponential.cpp:78:59: error: invalid use of incomplete type ‘class wxBrush’
   78 |         gc->SetBrush(wxBrush(m_selectionColour.GetDcRGBA()));
      |                                                           ^
In file included from /usr/include/wx-3.1/wx/event.h:21,
                 from /usr/include/wx-3.1/wx/window.h:18,
                 from /usr/include/wx-3.1/wx/nonownedwnd.h:14,
                 from /usr/include/wx-3.1/wx/toplevel.h:20,
                 from /usr/include/wx-3.1/wx/dialog.h:14,
                 from /usr/include/wx-3.1/wx/msgdlg.h:18,
                 from /home/roni/psp/PSP/Project/Element.h:21,
                 from /home/roni/psp/PSP/Project/ControlElement.h:21,
                 from /home/roni/psp/PSP/Project/Exponential.h:21,
                 from /home/roni/psp/PSP/Project/Exponential.cpp:18:
/usr/include/wx-3.1/wx/gdicmn.h:30:28: note: forward declaration of ‘class wxBrush’
   30 | class WXDLLIMPEXP_FWD_CORE wxBrush;
      |                            ^~~~~~~
/home/roni/psp/PSP/Project/Exponential.cpp:111:48: error: invalid use of incomplete type ‘class wxBrush’
  111 |     gc->SetBrush(wxBrush(wxColour(0, 0, 0, 255)));
      |                                                ^
In file included from /usr/include/wx-3.1/wx/event.h:21,
                 from /usr/include/wx-3.1/wx/window.h:18,
                 from /usr/include/wx-3.1/wx/nonownedwnd.h:14,
                 from /usr/include/wx-3.1/wx/toplevel.h:20,
                 from /usr/include/wx-3.1/wx/dialog.h:14,
                 from /usr/include/wx-3.1/wx/msgdlg.h:18,
                 from /home/roni/psp/PSP/Project/Element.h:21,
                 from /home/roni/psp/PSP/Project/ControlElement.h:21,
                 from /home/roni/psp/PSP/Project/Exponential.h:21,
                 from /home/roni/psp/PSP/Project/Exponential.cpp:18:
/usr/include/wx-3.1/wx/gdicmn.h:30:28: note: forward declaration of ‘class wxBrush’
   30 | class WXDLLIMPEXP_FWD_CORE wxBrush;
      |                            ^~~~~~~
make[2]: *** [CMakeFiles/PSP-UFU.dir/build.make:524: CMakeFiles/PSP-UFU.dir/Project/Exponential.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [CMakeFiles/Makefile2:83: CMakeFiles/PSP-UFU.dir/all] Error 2
make: *** [Makefile:91: all] Error 2
```
I find it funny that your compilers in your build environments do not complain about that, whereas both g++ (11.2.1) and clang++ (13.0.0) in Fedora 35 do complain about it. Why are my compilers less permissive?

But, in the end, it compiles and runs :-P
![psp_running](https://user-images.githubusercontent.com/3703639/140618483-f467b915-2863-47bd-a12e-9049ec5a30f5.png)
![grafico](https://user-images.githubusercontent.com/3703639/140618484-59d17cca-a172-4ef0-81f3-cf27188152a9.png)

